### PR TITLE
CMakeLists Build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(hiredis REQUIRED)
 
 add_subdirectory(extern/TCPunch/client/)
 
+find_package(ZLIB REQUIRED)
+
 add_library(FMI STATIC src/Communicator.cpp src/utils/Configuration.cpp src/comm/Channel.cpp src/comm/ClientServer.cpp
         src/comm/S3.cpp src/comm/Redis.cpp src/utils/ChannelPolicy.cpp src/comm/PeerToPeer.cpp src/comm/Direct.cpp)
 


### PR DESCRIPTION
This PR is Part of #17 

The build fails because it requires ZLIB. This PR adds the dependency using `find_package` to the `CMakeLists.txt` file