### PR TITLE
AWS S3 SDK Build fix

### DIFF
--- a/src/comm/S3.cpp
+++ b/src/comm/S3.cpp
@@ -25,7 +25,7 @@ FMI::Comm::S3::S3(std::map<std::string, std::string> params, std::map<std::strin
     upload_price = std::stod(model_params["upload_price"]);
 
     auto credentialsProvider = Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>(TAG);
-    client = Aws::MakeUnique<Aws::S3::S3Client>(TAG, credentialsProvider, config);
+    client = Aws::MakeUnique<Aws::S3::S3Client>(TAG, config);
 }
 
 FMI::Comm::S3::~S3() {


### PR DESCRIPTION
Part of #17 

The lambda layer build fails due to an additional parameter in the S3Client constructor.
Newer version of the AWS S3 SDK does not require that extra parameter ie credentialsProvider